### PR TITLE
Ig build error fixes

### DIFF
--- a/input/fsh/codesystems/Vaccines.fsh
+++ b/input/fsh/codesystems/Vaccines.fsh
@@ -14,16 +14,16 @@ Title: "Kenya Vaccine Codes"
 * #BCG ^property.valueCoding = $cvx#19
 * #OPV "OPV" "Oral Polio Vaccine"
 * #OPV ^property.code = #cvxp
-* #OPV ^property.valueCode = $cvx#2
+* #OPV ^property.valueCoding = $cvx#02
 * #PCV "PCV 10" "Pneumococcal Conjugate Vaccine"
 * #PCV ^property.code = #cvxp
-* #PCV ^property.valueCode = $cvx#177
+* #PCV ^property.valueCoding = $cvx#177
 * #Rota "Rota" "Rotavirus vaccine"
 * #Rota ^property.code = #cvxp
-* #Rota ^property.valueCode = $cvx#122
+* #Rota ^property.valueCoding = $cvx#122
 * #DTP-Hib-Hep-B "DTP-Hib-Hep B" "Diptheria, Pertussis, Haemophilus influenzae type b"
 * #DTP-Hib-Hep-B ^property.code = #cvxp
-* #DTP-Hib-Hep-B ^property.valueCode = $cvx#102
+* #DTP-Hib-Hep-B ^property.valueCoding = $cvx#102
 
 
 CodeSystem: KenyanImmunizationNotDoneReasonsCS

--- a/input/fsh/extensions/immunization.fsh
+++ b/input/fsh/extensions/immunization.fsh
@@ -1,0 +1,11 @@
+Extension: ReactionSeverityExtension
+Id: reaction-severity
+Title: "ReactionSeverityExtension"
+Description: "ReactionSeverityExtension"
+* value[x] only code
+
+Extension: AefiOutcomeExtension
+Id: aefi-outcome
+Title: "AefiOutcomeExtension"
+Description: "AefiOutcomeExtension"
+* value[x] only code

--- a/input/fsh/extensions/practitioner.fsh
+++ b/input/fsh/extensions/practitioner.fsh
@@ -1,0 +1,5 @@
+Extension: KenyaAdministrativeGenderExtension
+Id: kenya-administrative-gender-extension
+Title: "KenyaAdministrativeGenderExtension"
+Description: "KenyaAdministrativeGenderExtension"
+* value[x] only code

--- a/input/fsh/extensions/stockAdjustment.fsh
+++ b/input/fsh/extensions/stockAdjustment.fsh
@@ -111,7 +111,7 @@ Description: "AExtension for Stock Adjustment Type"
 Context: SupplyDelivery
 // url, status, purpose, and other metadata could be defined here using caret syntax (omitted)
 * value[x] only code
-* value[x] from StockAdjustmentVs
+* valueCode from StockAdjustmentVs
 
 
 

--- a/input/fsh/models/IMMZARegisterClient.fsh
+++ b/input/fsh/models/IMMZARegisterClient.fsh
@@ -40,7 +40,7 @@ Description:  "Data elements for the IMMZ.A Register Client Data Dictionary."
     * ^code[+] = IMMZ.A#DE32
 * healthWorker 1..1 boolean "Active health worker" "Is the client an active and participating health worker. This data element is used mainly for reporting and indicators purposes."  
   * ^code[+] = IMMZ.A#DE21
-* generalPractitioner 1..1 Reference "Practitioner" "A person with a formal responsibility in the provisioning of healthcare or related services"
+* generalPractitioner 1..1 BackboneElement "Practitioner" "A person with a formal responsibility in the provisioning of healthcare or related services"
   * name 1..1 string "CHP's name"
     * ^code[+] = IMMZ.A#DE31
   * telecom 1..1 string "CHP's mobile phone"  

--- a/input/fsh/models/IMMZCoreDataSets.fsh
+++ b/input/fsh/models/IMMZCoreDataSets.fsh
@@ -1,5 +1,6 @@
 
 Logical:      VaccinationCertificateCoreDataSet
+Id: vaccination-certificate-core-data-set
 Title:        "IMMZ.J Vaccination Core DataSets"
 Description:  "Data elements for the IMMZ.J Vaccination Certificate CoreDataSet Data Dictionary."
 * ^extension[http://hl7.org/fhir/tools/StructureDefinition/logical-target].valueBoolean = true
@@ -32,6 +33,7 @@ Title:          "WHO Digital Documentation of COVID Certificates"
 
 
 Logical:        VaccinationCertificate_VS
+Id: vaccination-certificate-vs  
 Title:          "IMMZ.H Vaccination Status"
 Parent:         VaccinationCertificateCoreDataSet
 Description:    "Data elements for the IMMZ.H Vaccination Status Data Dictionary."
@@ -39,7 +41,7 @@ Description:    "Data elements for the IMMZ.H Vaccination Status Data Dictionary
 * ^name = "VaccinationCertificate_VS"
 * ^status = #active
 * ^abstract = true
-* ^type = "VaccinationCertificateCoreDataSet"
+* ^type = "http://example.org/fhir/StructureDefinition/vaccination-certificate-core-data-set"
 
 * vaccination 1..1 BackboneElement "Vaccination Event"
   * ^code[+] = IMMZ.H#DE4 
@@ -77,6 +79,7 @@ Description:    "Data elements for the IMMZ.H Vaccination Status Data Dictionary
 
 
 Logical:      VaccinationCertificate_CoC
+Id:          vaccination-certificate-coc
 Title:        "IMMZ.G Vaccination Status- Continuity of Care"
 Parent:       VaccinationCertificate_VS
 Description:  "Data elements for the IMMZ.G Vaccination Status - Continuity of Care Data Dictionary."
@@ -84,14 +87,15 @@ Description:  "Data elements for the IMMZ.G Vaccination Status - Continuity of C
 * ^name = "VaccinationCertificate_CoC"
 * ^status = #active
 * ^abstract = true
-* ^type = "VaccinationCertificate_VS"
+* ^type = "http://example.org/fhir/StructureDefinition/vaccination-certificate-vs"
 
-* vaccination 0..1 BackboneElement "Vaccination" 
-  * centre 1..1 string "Centre" "Administering centre"
+// * vaccination 0..1 BackboneElement "Vaccination" 
+//   * centre 1..1 string "Centre" "Administering centre"
 * sex 0..1 code "Sex" "Administrative gender"
 
 
 Logical:      VaccinationCertificate_PoV
+Id:         vaccination-certificate-pov
 Title:        "IMMZ.K Vaccination Status- Proof of Vaccination"
 Parent:       VaccinationCertificate_VS
 Description:  "Data elements for the IMMZ.K Vaccination Status - Proof of Vaccination Dictionary."
@@ -99,5 +103,5 @@ Description:  "Data elements for the IMMZ.K Vaccination Status - Proof of Vaccin
 * ^name = "VaccinationCertificate_PoV"
 * ^status = #active
 * ^abstract = true
-* ^type = "VaccinationCertificate_VS"
+* ^type = "http://example.org/fhir/StructureDefinition/vaccination-certificate-vs"
 

--- a/input/fsh/models/IMMZDDefaulterTracing.fsh
+++ b/input/fsh/models/IMMZDDefaulterTracing.fsh
@@ -7,7 +7,7 @@ Description:  "Data elements for the IMMZ.D Defaulter Tracing Data Dictionary."
 * ^status = #active
 
 * childCanBeLocated 1..1 SU code "Child can be located"
-* clientInformation 1..1 Reference "Patient" "Send client’s information to CHP"
+* clientInformation 1..1 BackboneElement "Patient" "Send client’s information to CHP"
   * name 1..1 BackboneElement "Name of the Client send to the CHP"
     * given 1..1 string "First name" "Client's first name or given name"
     * family 1..1 string "Last name" "Client's first name or family name"

--- a/input/fsh/profiles/adverseEvent.fsh
+++ b/input/fsh/profiles/adverseEvent.fsh
@@ -6,7 +6,8 @@ Alias: $treatment-given = http://example.org/StructureDefinition/treatment-given
 Alias: $treatment-details  = http://example.org/StructureDefinition/treatment-details 
 Alias: $specimen-collected = http://example.org/StructureDefinition/specimen-collected
 Alias: $specimen-details  = http://example.org/StructureDefinition/specimen-details 
-
+Alias: $reaction-severity = http://example.org/StructureDefinition/reaction-severity
+Alias: $aefi-outcome = http://example.org/StructureDefinition/aefi-outcome
 
 Profile: AdverseEventProfile
 Parent: AdverseEvent
@@ -19,24 +20,31 @@ Description: "Profile for Adverse Event"
     $treatment-given named treatmentGiven 0..1 MS and 
     $treatment-details named treatmentDetails 0..1 MS and 
     $specimen-collected named specimenCollected 0..1 MS and 
-    $specimen-details named specimenDetails 0..1 MS  
-     
+    $specimen-details named specimenDetails 0..1 MS and
+    $reaction-severity named reactionSeverity 1..1 MS and
+    $aefi-outcome named aefiOutcome 1..1 MS
+
 * identifier 1..1 MS
 * actuality 1..1 MS
 * date 1..1 MS
 * subjectMedicalHistory 1..1 MS
 * subjectMedicalHistory only Reference(Condition or Observation or Immunization or DocumentReference)
-* severity 1..1 MS
-* severity from reactionSeverityVS
-* severity ^short = "Life Threatening | Mild | Moderate | Severe | Fatal "
-* outcome 1..1 MS
-* outcome from aefiOutcomeVS
-* outcome ^short = "Recovered | Recovering | Not Recovered | Unknown | Died "
+// * severity 1..1 MS
+// * severity from reactionSeverityVS
+// * severity ^short = "Life Threatening | Mild | Moderate | Severe | Fatal "
+// * outcome 1..1 MS
+// * outcome from aefiOutcomeVS
+// * outcome ^short = "Recovered | Recovering | Not Recovered | Unknown | Died "
 * subject only Reference (KenyanImmunizationRegistryPatient)
 * recordedDate 1..1 MS
 * suspectEntity 0..1 MS
 * suspectEntity.instance 1..1 MS
 * suspectEntity.instance only Reference (Substance)
+
+* extension[reaction-severity].valueCode from reactionSeverityVS
+* extension[reaction-severity].valueCode ^short = "Life Threatening | Mild | Moderate | Severe | Fatal "
+* extension[aefi-outcome].valueCode from aefiOutcomeVS
+* extension[aefi-outcome].valueCode ^short = "Recovered | Recovering | Not Recovered | Unknown | Died "
 
 Instance: ExampleAdverseEvent
 InstanceOf: AdverseEventProfile
@@ -46,12 +54,12 @@ Description: "An example instance of an adverse event profile."
 * identifier.value = "AE123456789"
 * actuality = #actual
 * date = "2024-05-12"
-* subjectMedicalHistory = Reference(http://example.org/StructureDefinition/Condition/123453)
-* severity = #DE27
-* outcome = #DE34
-* subject = Reference(http://example.org/StructureDefinition/KenyanImmunizationRegistryPatient/12345)
+* subjectMedicalHistory = Reference(ConditionExample)
+// * severity = #DE27
+// * outcome = #DE34
+* subject = Reference(PatientExample)
 * recordedDate = "2024-05-13"
-* suspectEntity.instance = Reference(http://example.org/StructureDefinition/Substance/67890)
+* suspectEntity.instance = Reference(SubstanceExample)
 * extension[types-of-aefi].valueCode = #DE3
 
 * extension[event-details].valueString = "Patient developed a rash within 24 hours of vaccination."
@@ -61,3 +69,27 @@ Description: "An example instance of an adverse event profile."
 * extension[treatment-details].valueString = "Administered antihistamine."
 * extension[specimen-collected].valueString = "Specimen x"
 * extension[specimen-details].valueString = "No specimens collected."
+* extension[reaction-severity].valueCode = #DE27
+* extension[aefi-outcome].valueCode = #DE34
+
+
+// Instance: EncounterExample
+// InstanceOf: Encounter
+// Title: "Example Encounter"
+// Description: "An example instance of an encounter."
+// * status = #finished
+
+Instance: SubstanceExample
+InstanceOf: Substance
+Title: "SubstanceExample"
+Description: "Example Substance"
+* code.coding.system = "http://snomed.info/sct"
+* code.coding.code = #102002
+* code.coding.display = "Hemoglobin Okaloosa"
+* code.text = "Hemoglobin Okaloosa"
+
+Instance: ConditionExample
+InstanceOf: Condition
+Title: "Example Condition"
+Description: "An example instance of a condition."
+* subject = Reference(PatientExample)

--- a/input/fsh/profiles/immunization.fsh
+++ b/input/fsh/profiles/immunization.fsh
@@ -96,4 +96,9 @@ Usage: #example
 * expirationDate = "2023-11-01"
 * performer.function.coding[0] = $v2-0443#AP
 * performer.function.coding[+] = http://example.org/tz/actors#xxx
-* performer.actor = Reference(http://example.org/StructureDefinition/Practitioner/253373)
+* performer.actor = Reference(PractitionerExample)
+
+
+Instance: PractitionerExample
+InstanceOf: Practitioner
+Usage: #example

--- a/input/fsh/profiles/practitioner.fsh
+++ b/input/fsh/profiles/practitioner.fsh
@@ -1,12 +1,13 @@
 Alias: $kenya-counties-extension = http://example.org/StructureDefinition/kenya-counties-extension
+Alias: $kenya-administrative-gender-extension = http://example.org/StructureDefinition/kenya-administrative-gender-extension
 
 
 Profile: KenyanPractitioner
 Parent: Practitioner
 Description: "Profile for a Kenyan Practitioner"
 * extension contains 
-    $kenya-counties-extension named location 0..1 
-
+    $kenya-counties-extension named location 0..1 and
+    $kenya-administrative-gender-extension named kenyaAdministrativeGenderExtension 0..1
 * identifier 0..* MS
 * identifier.system 1..1
 * identifier.system ^short = "The namespace for the identifier value e.g a Registry URL"
@@ -18,6 +19,8 @@ Description: "Profile for a Kenyan Practitioner"
 * telecom 0..* 
 * telecom.system 1..1
 * telecom.value 1..1
-* gender from kenyaAdministrativeGenderVS 
-* gender ^short = "male | female |"
+// * gender from kenyaAdministrativeGenderVS 
+// * gender ^short = "male | female |"
 * birthDate MS
+* extension[kenya-administrative-gender-extension].valueCode from kenyaAdministrativeGenderVS
+* extension[kenya-administrative-gender-extension] ^short = "male | female |"

--- a/input/fsh/profiles/supplyDelivery.fsh
+++ b/input/fsh/profiles/supplyDelivery.fsh
@@ -24,7 +24,7 @@ Profile: SupplyDeliveryProfile
 Parent: SupplyDelivery
 Description: "Record of delivery of what is supplied."
 * extension contains
-    $date-received named date-received 0..1 MS and
+    $date-received named dateReceived 0..1 MS and
     $origin named origin  0..1 MS and 
     $order-number named orderNumber  0..1 MS and
     $vaccine named vaccine  0..1 MS and 
@@ -43,14 +43,13 @@ Description: "Record of delivery of what is supplied."
     $previous-vvm named previousVVM  0..1 MS and
     $new-vvm named newVVM  0..1 MS and 
     $physical-count named physicalCount 0..1 MS and 
-    $stock-adjustment-date named stockAdjustmentDate 0..1 MS and 
-    $adjustment-type named adjustmentType  0..1 MS
+    $stock-adjustment-date named stockAdjustmentDate 0..1 MS
 
     
 * identifier 1..1 MS
+* suppliedItem.item[x] only Reference
 * suppliedItem.itemReference 1..1 MS
 * suppliedItem.itemReference only Reference(Medication) 
 * suppliedItem.quantity 1..1 MS
 * type 1..1 MS
 * type ^short = "VVM Status"
-

--- a/input/fsh/profiles/supplyRequest.fsh
+++ b/input/fsh/profiles/supplyRequest.fsh
@@ -13,7 +13,7 @@ Profile: SupplyRequestProfile
 Parent: SupplyRequest
 Description: "A record of a request for a medication, substance or device used in the healthcare setting."
 * extension contains
-     $date-of-last-order named  $date-of-last-order 0..1 MS and
+     $date-of-last-order named  date-of-last-order 0..1 MS and
      $expected-date-of-next-order named expected-date-of-next-order  0..1 MS and
      $total-population named total-population  0..1 MS and
      $children named children   0..1 MS and

--- a/input/fsh/valuesets/IMMZBValueset.fsh
+++ b/input/fsh/valuesets/IMMZBValueset.fsh
@@ -135,7 +135,8 @@ Title: "Combination Codes for vaccine"
 Description: "This is a mixed value set"
 * ^version = "0.1.0"
 * ^experimental = false
-* $cvx#3
+* $cvx#02
+* $cvx#03
 * $cvx#19
 * $cvx#137
 * $cvx#178

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -95,9 +95,9 @@ pages:
 # │ input/includes. To use a provided input/includes/menu.xml file, delete the "menu"              │
 # │ property below.                                                                                │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-menu:
-  Home: index.html
-  Artifacts: artifacts.html
+# menu:
+#   Home: index.html
+#   Artifacts: artifacts.html
 
 # ╭───────────────────────────Less Common Implementation Guide Properties──────────────────────────╮
 # │  Uncomment the properties below to configure additional properties on the ImplementationGuide  │


### PR DESCRIPTION
The following changes were done:

Sushi-config.yaml

- removed menu attribute since there is the custom file input/includes/menu.xml

Vaccines.fsh

- set approprate data types and put appropriate codes that exist in the codesystem

input/fsh/extensions/immunization.fsh, input/fsh/profiles/adverseEvent.fsh

- the severity and outcome fields have their original valuesets in the AdverseEvent profile making it impossible to assign other codes. Even if we have our own valueset, we cannot override the valueset for the parent resource.

input/fsh/extensions/practitioner.fsh, input/fsh/profiles/practitioner.fsh

- added gender as an extension since one cannot override the parent valueset

IMMBZValueset.fsh

- Modified codes to correct codes

IMMZARegisterClient.fsh

- changed Reference to Backbone Element in order to maintain the children of the element. Reference cannot have children (this conclusion is based off my experimentation and observing other IGs)

IMMZCoreDataSets.fsh

- Added id attribute
- Corrected type attribute

supplyDelivery.fsh

- added proper restriction to the suppliedItem.itemReference

supplyRequest.fsh
Removed $. It was erroneous
